### PR TITLE
Added Filter for serving gzipped files (fixed)

### DIFF
--- a/src/main/java/org/realityforge/gwt/cache_filter/GWTGzipControlFilter.java
+++ b/src/main/java/org/realityforge/gwt/cache_filter/GWTGzipControlFilter.java
@@ -3,23 +3,71 @@ package org.realityforge.gwt.cache_filter;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.*;
+import java.util.*;
 
 /**
- * Filter to redirect all files to their corresponding .gz file, if it exists, and serve
- * it with the proper encoding / content type. Works best if called after GWTCacheControlFilter
+ * Checks to see if a gzipped file for the given request url exists, and serves that file if
+ * it does (and if its isn't present in its ignore list). This filter doesn't call chain.doFilter
+ * if a gzipped file is found. It is best placed AFTER GWTCacheControlFilter in your web.xml,
+ * so any cache headers would be set before the gzipped file is served.
+ *
+ * For each request, this filter checks to see if:
+ * 1) The browser accepts gzip encoding (via the Accept-Encoding header)
+ *
+ * 2) A file with the request url + .gz exists and is readable, and isn't in the ignore list,
+ *   and has a mime type available for it. (The .gz extension is configurable, see below).
+ *
+ * 3) If those conditions match, it then sets the 'Content Encoding' header to gzip, and serves
+ * the gzipped file instead of the non-gzipped version.
+ *
+ * 4) This filter does not call chain.doFilter() if the above conditions match. It should be
+ * placed at the end of all other filters in your web.xml.
+ *
+ * Example: user goes to example.com/foo.js. If example.com/foo.js.gz exists, then
+ * example.com/foo.js.gz is served instead of foo.js
+ *
+ * IMPORTANT: This filter does not call chain.doFilter() if a gzipped file is matched. It simply
+ * serves that file.
+ *
+ * IMPORTANT: Make sure to add any urls that you don't want to be served (but which have
+ * a .gz file available) to the ignore list. This can be done by passing them as an
+ * init parameter, as a comma separated string.
+ *
+ * <init-param>
+ *     <param-name>ignoredList</param-name>
+ *    <param-value>foo/bar/baz.html, bar*</param-value>
+ * </init-param>
+ *
+ * In the above case, any urls matching /foo/bar/baz.html would be ignored, even
+ * if the file /foo/bar/baz.html.gz exists. Similarly, any urls that start with bar will not
+ * be served. E.g /bar1.js, /bar2.png, /bar3/foo/1.html, etc.
+ *
+ * WEB-INF* is added to the ignored list by default.
+ *
+ * The default extension for gzipped files is ".gz", it can be changed via this parameter:
+ *
+ *<init-param>
+ *     <param-name>gzipExtension</param-name>
+ *     <param-value>.foo</param-value>
+ *</init-param>
+ *
+ * TODO: Check for the 304 header in the incoming request, and use file.lastModified() to
+ * see if the file has modified since the last time it was viewed. If the file hasn't
+ * been modified, send a 'not modified' header, otherwise serve the file.
+ *
  */
+
 public class GWTGzipControlFilter implements Filter
 {
     private static String gzExt = ".gz";
     private static final Map<String, String> mimeTypes = new HashMap<>();
+    private static final List<String> ignoredUrls = new ArrayList<>();
 
     static
     {
+        ignoredUrls.add("WEB-INF/*");
+
         mimeTypes.put(".txt", "text/plain");
         mimeTypes.put(".html", "text/html");
         mimeTypes.put(".xhtml", "application/xhtml+xml");
@@ -45,22 +93,58 @@ public class GWTGzipControlFilter implements Filter
         mimeTypes.put(fileExtWithDot, mimeType);
     }
 
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {}
+    public static boolean addIgnoredUrl(String url)
+    {
+        url = url.trim().toLowerCase();
+        if (url.isEmpty() )
+            return false;
+
+        if (! url.startsWith("/"))
+            url = "/" + url;
+
+        ignoredUrls.add(url.toLowerCase() );
+        return true;
+    }
 
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException
+    public void init(FilterConfig config) throws ServletException
+    {
+        setGzipExtension( config.getInitParameter("gzipExtension")  );
+        String[] ignoredUrls = parseByComma( config.getInitParameter("ignoredUrls") );
+        if (ignoredUrls != null && ignoredUrls.length > 0)
+        {
+            for (String ignoredUrl : ignoredUrls)
+            {
+                addIgnoredUrl(ignoredUrl);
+            }
+        }
+    }
+
+    private String[] parseByComma(String param)
+    {
+        if (param == null)
+            return null;
+
+        if (param.isEmpty() )
+            return null;
+
+        return param.split(",");
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException
     {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
         final HttpServletResponse response = (HttpServletResponse) servletResponse;
+        final String reqUrl = request.getRequestURI();
 
-        if (! acceptsGzip(request))
+        if (! acceptsGzip(request) || isIgnored(reqUrl))
         {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String reqUrl = request.getRequestURI();
         String reqPath = request.getServletContext().getRealPath( reqUrl );
         File reqFile = new File(reqPath);
         if (! reqFile.exists() || reqFile.isDirectory() )
@@ -69,35 +153,69 @@ public class GWTGzipControlFilter implements Filter
             return;
         }
 
-        if (reqUrl.endsWith(gzExt))
-        {
-            /***
-             Just using response.setContentType() doesn't work, it gets reset
-             when filterChain.doFilter() is called. A custom response wrapper has
-             to be made, which would force the content type. See:
-             http://stackoverflow.com/a/24846284/49153
-             ****/
-
-            ForcableContentTypeWrapper newResponse = new ForcableContentTypeWrapper(response);
-            newResponse.setHeader("Content-Encoding", "gzip");
-            newResponse.forceContentType( getMimeType(reqUrl, true) );
-            filterChain.doFilter(request, newResponse);
-            return;
-        }
-
         String gzippedPath = reqPath + gzExt;
         File gzippedFile = new File(gzippedPath );
 
-        if (! gzippedFile.exists() || gzippedFile.isDirectory() )
+        if (! gzippedFile.exists() || gzippedFile.isDirectory() || ! gzippedFile.canRead() )
         {
             filterChain.doFilter( request, servletResponse );
             return;
         }
+        String mime = getMimeType(reqUrl);
+        if (mime != null)
+            sendGzipped(request, response, mime, gzippedFile);
+        else
+            filterChain.doFilter(request, response);
+    }
 
-        String gzippedUrl = reqUrl + gzExt;
+    private boolean isIgnored(String url)
+    {
+        url = url.toLowerCase();
+        for (String ignoredUrl : ignoredUrls)
+        {
+            boolean hasWildCard = ignoredUrl.endsWith("*");
+            if (! hasWildCard && url.equals(ignoredUrl) )
+                return true;
 
-        response.sendRedirect(gzippedUrl);
-        filterChain.doFilter(request, response);
+            if (! hasWildCard)
+                continue;
+
+            String cleanedIgnored = ignoredUrl.substring(0, ignoredUrl.length() - 1);
+            if ( url.startsWith(cleanedIgnored) )
+                return true;
+        }
+        return false;
+    }
+
+    private void sendGzipped(HttpServletRequest request, HttpServletResponse response,
+                             String mimeType, File gzippedFile)
+            throws IOException
+    {
+        response.setStatus(200);
+        if ( response.getHeader("Date") == null)
+            response.setDateHeader("Date", new Date().getTime() );
+
+        if (response.getHeader("Last-Modified") == null)
+            response.setDateHeader("Last-Modified", gzippedFile.lastModified());
+        response.setHeader("Content-Encoding", "gzip");
+        response.setContentType( mimeType );
+        response.setContentLength( (int) gzippedFile.length() );
+        readBinaryData(gzippedFile, response);
+    }
+
+    private void readBinaryData(File binaryFile, ServletResponse response)
+            throws IOException
+    {
+        FileInputStream is = new FileInputStream(binaryFile);
+        OutputStream out = response.getOutputStream();
+        byte[] buffer = new byte[2048];
+        int bytesRead;
+        while ((bytesRead = is.read(buffer)) != -1)
+        {
+            out.write(buffer, 0, bytesRead);
+        }
+        out.flush();
+        is.close();
     }
 
     public static boolean acceptsGzip(HttpServletRequest request)
@@ -106,32 +224,12 @@ public class GWTGzipControlFilter implements Filter
         return ( header != null && header.contains("gzip") );
     }
 
-    public static String getMimeType(String filePath, boolean removeGzExtension)
+    public static String getMimeType(String filePath)
     {
-        if (removeGzExtension)
-            filePath = filePath.substring(0, filePath.length() - gzExt.length());
-
         String ext = filePath.substring( filePath.lastIndexOf("."), filePath.length() );
-        return (mimeTypes.containsKey(ext)) ? mimeTypes.get(ext) : mimeTypes.get(gzExt);
+        return (mimeTypes.containsKey(ext)) ? mimeTypes.get(ext) : null;
     }
 
     @Override
     public void destroy(){}
-
-    private class ForcableContentTypeWrapper extends HttpServletResponseWrapper
-    {
-        public ForcableContentTypeWrapper(HttpServletResponse response)
-        {
-            super(response);
-        }
-
-        @Override
-        public void setContentType(String type)
-        {
-        }
-        public void forceContentType(String type)
-        {
-            super.setContentType(type);
-        }
-    }
 }


### PR DESCRIPTION
Hey there,

This is a great little filter which improves the performance quite a lot. One thing which was missing, was that it doesn't also gzip all the gwt files. If a GWT project inherits from com.google.gwt.precompress.Precompress, then all its compiled files get their own .gz version, which contain the gzipped version of their output.

I've written a small filter which works great with those files. It checks if the incoming request has a .gz version, if so, it redirects to serve that version, and sets the correct encoding / content type, etc.

For example, if someone goes to example.com/Module/Module.nocache.js, they would be redirected to example.com/Module/Module.nocache.js.gz, with the proper headers set to serve it as a gzipped file.

Hope this is useful. This filter works best if called after the GWTCacheControlFilter, since for .cache files, that filter would set the cache headers before the redirect is sent by this filter.
